### PR TITLE
Show number of connected machines in the Dashboard

### DIFF
--- a/src/copilot-dashboard/js/dashboard2.config.js
+++ b/src/copilot-dashboard/js/dashboard2.config.js
@@ -9,10 +9,20 @@
       "type": "area",
       "refreshRate": 60
     },
-  
+
+    {
+      "title": "Connected machines (last week)",
+      "id": "machines-last-week",
+      "metrics": ["summarize(copilot.ejabberd.*.connect, \"1d\")"],
+      "labelPattern": "Number of agents",
+      "range": "-7d",
+      "type": "area",
+      "minValue": 0
+    },
+
     {
       "title": "System load",
-      "id": "system-load-combined", 
+      "id": "system-load-combined",
       "metrics": ["copilot.jobmanager.generic.*.system.load.1min"],
       "labelPattern": "JM {0}",
       "range": "-6h",
@@ -23,7 +33,7 @@
 
     {
       "title": "Available memory",
-      "id": "mem-usage-combined", 
+      "id": "mem-usage-combined",
       "metrics": ["copilot.jobmanager.generic.*.system.ram.available.mem"],
       "labelPattern": "JM {0}",
       "range": "-6h",
@@ -34,7 +44,7 @@
 
     {
       "title": "Available swap",
-      "id": "swap-usage-combined", 
+      "id": "swap-usage-combined",
       "metrics": ["copilot.jobmanager.generic.*.system.ram.available.swap"],
       "labelPattern": "JM {0}",
       "range": "-6h",
@@ -45,7 +55,7 @@
 
     {
       "title": "Network traffic",
-      "id": "net-io-combined", 
+      "id": "net-io-combined",
       "metrics": ["copilot.jobmanager.generic.*.system.net.*.eth0"],
       "labelPattern": "eth0 {1} (JM {0})",
       "range": "-6h",
@@ -83,8 +93,8 @@
       "range": "-3min",
       "refreshRate": 60
     },
-    
-    
+
+
     {
       "title": "Jobs rates (last week)",
       "id": "jobs-last-week-combined",
@@ -100,7 +110,7 @@
       "refreshRate": 3600,
       "minValue": 0
     },
-    
+
     {
       "title": "Jobs rates (last 6 hours)",
       "id": "jobs-recent-combined",
@@ -116,7 +126,7 @@
       "refreshRate": 10,
       "minValue": 0
     },
-    
+
     {
       "title": "Job duration",
       "id": "jobs-duration-combined",
@@ -127,7 +137,7 @@
       "refreshRate": 10,
       "minValue": 0
     },
-    
+
     {
       "title": "Errors",
       "id": "errors-combined",
@@ -145,7 +155,8 @@
 
     [[3, 9], ["mem-usage-overview", "disk-usage-overview"],
              ["system-load-combined", "mem-usage-combined", "swap-usage-combined", "net-io-combined", "disk-usage-combined"]],
-    
+
+    [[12],   ["machines-last-week"]],
     [[12],   ["jobs-last-week-combined", "jobs-recent-combined"]],
 
     [[6, 6], ["errors-combined"],  ["jobs-duration-combined"]]

--- a/src/copilot-dashboard/js/dashboard2.js
+++ b/src/copilot-dashboard/js/dashboard2.js
@@ -16,12 +16,12 @@ window.Dashboard = {
     this.updateClock();
     setInterval(this.updateClock.bind(this), 60*1000);
   },
-  
+
   loadConfig: function () {
     console.log('Loading config');
     $.getJSON('js/dashboard2.config.js?r='+Math.random(), this.parseConfig.bind(this));
   },
-  
+
   parseConfig: function (config) {
     this.config = config;
     console.log('Loaded configuration file', config);
@@ -35,11 +35,11 @@ window.Dashboard = {
         graphs = this.config.graphs,
         rowConfig, graphIds, graphsCount,
         group, i, ii, j, jj, k, kk, gid;
-    
+
     for(i = 0, ii = layout.length; i < ii; i++) {
       rowConfig = layout[i][0];
       graphIds = layout[i].slice(1);
-      
+
       for(j = 0, jj = rowConfig.length; j < jj; j++) {
         group = $('<div class="group grid_' + rowConfig[j] +'"/>');
 
@@ -74,7 +74,7 @@ window.Dashboard = {
       graphs[n] = new Graph(graphs[n]);
       n -= 1;
     };
-    
+
     this._loadNext();
   },
 
@@ -90,10 +90,10 @@ var _replaceRegex = /\{(\d+)\}/g;
 function mapPath(pattern, path, str) {
   pattern = pattern.split('.');
   path = path.split('.');
-  
+
   var mapping = {},
       x = pattern.length, n, m = 0;
-  
+
   for(n = 0; n < x; n++)
     if(pattern[n] === '*')
       mapping[m++] = path[n];
@@ -105,7 +105,7 @@ function Graph(options) {
   this.options = options;
   this.id = options.id || Graph.COUNT++;
   console.log('Initialising new graph', options);
-  
+
   this._el = $(document.getElementById('g-' + this.id));
   if(!this._el.length) {
     setTimeout(function () { Dashboard._loadNext() }, 1);
@@ -152,7 +152,7 @@ function Graph(options) {
 
   if('minValue' in options)
     chartOptions.yAxis.min = options.minValue;
-  
+
   if(options.type === 'pie') {
     chartOptions.plotOptions.series.dataLabels = {enabled: false};
     chartOptions.plotOptions.series.showInLegend = true;
@@ -167,7 +167,7 @@ function Graph(options) {
   }
   if(options.stacking)
     chartOptions.plotOptions.series.stacking = options.stacking;
-  
+
   var metrics = [];
   for(var metric in options.labels) {
     chartOptions.series.push({
@@ -177,10 +177,10 @@ function Graph(options) {
     metrics.push(metric);
   }
   this._metrics = metrics;
-  
+
   this.g = new Highcharts.Chart(chartOptions);
   this._el.prepend('<span class="title">' + options.title + '</span>');
-  
+
   //setTimeout(function () { Dashboard._loadNext(); }, 1);
 
   return this;
@@ -195,12 +195,12 @@ Graph.prototype = {
               this.options.metrics.map(function (x) { return 'target=' + encodeURIComponent(x) }).join('&'),
               'uniq=' + Math.random()
             ];
-    
+
     if(this._lastUpdate)
       q.push('from=' + this._lastUpdate, 'until=now');
     else
       q.push('from=' + this.options.range, 'until=now');
-    
+
     return q.join('&');
   },
   patternForPath: function (path) {
@@ -212,13 +212,13 @@ Graph.prototype = {
     while(n--) {
       var pattern = metrics[n].split('.'),
           m = pattern.length;
-      
+
       if(path.length !== m) continue;
 
       while(m--)
         if(pattern[m] !== '*' && pattern[m] !== path[m])
           continue patternLoop;
-      
+
       return metrics[n];
     }
   },
@@ -227,7 +227,7 @@ Graph.prototype = {
     if(this.options.type !== 'pie')
       options.name = mapPath(this.patternForPath(path), path, this.options.labelPattern);
 
-    this.g.addSeries(options, false, false);    
+    this.g.addSeries(options, false, false);
     return this._metrics.push(path) - 1;
   },
   path2index: function (path) {
@@ -237,7 +237,8 @@ Graph.prototype = {
     var q = this.buildQuery();
     console.log('GET /render?' + q);
     $.get('/render?' + q, this.parseResponse.bind(this));
-    setTimeout(this.refresh.bind(this), (this.options.refreshRate || 60) * 1000);
+    if(this.options.refreshRate !== 0)
+      setTimeout(this.refresh.bind(this), (this.options.refreshRate || 60) * 1000);
   },
   parseResponse: function (data) {
     setTimeout(function () { Dashboard._loadNext(); }, 1);
@@ -252,9 +253,9 @@ Graph.prototype = {
         delta   = this.options.refreshRate * 1000,
         series  = data.split('\n'),
         n       = series.length;
-    
+
     if(pie) {
-      var updates = [], sum = 0, 
+      var updates = [], sum = 0,
           labelPattern = this.options.labelPattern,
           labels = this.options.labels,
           pattern, label;

--- a/src/copilot-ejabberd-module/src/mod_copilot.erl
+++ b/src/copilot-ejabberd-module/src/mod_copilot.erl
@@ -90,7 +90,7 @@ handle_cast({disconnect, {User, Host, Resource} = JID, _IPAddress}, State) ->
                                       host, bson:utf8(Host),
                                       resource, bson:utf8(Resource),
                                       connected, true}),
-    case doc_close_connection(mongo:next(Cursor), JID) of
+    case doc_close_connection(mongo:next(Cursor)) of
       {ok, NewDoc} -> mongo:save(connections, NewDoc);
       {failure, Reason} ->
         ?DEBUG("Failed to mark connection from ~p as closed: ~p", [JID, Reason]),
@@ -152,7 +152,7 @@ lookup_ip(IPAddress) ->
 %@doc Parses JID (username part) of an agent (ex.: agent_s-10829_1_7_18225d4f-e3f7-4c18-9a18-d6c06992d272_-g)
 parse_component_jid(User) ->
   case string:tokens(User, "_") of
-    ["agent"|_] = Props -> lists:zip([component, version, cores, jobs, uuid, ukn], lists:map(fun bson:utf8/1, Props));
+    ["agent"|_] = Props -> lists:zip([component, id, cpus, rev, uuid, ukn], lists:map(fun bson:utf8/1, Props));
     [Component|_] -> [{component, bson:utf8(Component)}]
   end.
 
@@ -161,22 +161,22 @@ doc_create_connection({User, Host, Resource}, IPAddress) ->
   GeoData = lookup_ip(IPAddress),
   Lng = proplists:get_value(longitude, GeoData),
   Lat = proplists:get_value(latitude, GeoData),
+  % Converts a list of tuples ([{x, Val}]) into a list of lists ([[x, Val]]) and flattens it ([x, Val]) for BSON
+  AgentData = erlang:list_to_tuple(lists:flatmap(fun erlang:tuple_to_list/1, parse_component_jid(User))),
 
   {user,         bson:utf8(User),
    host,         bson:utf8(Host),
    resource,     bson:utf8(Resource),
    loc,          [Lng, Lat],
+   agent_data,   AgentData,
    connected_at, bson:timenow(),
    connected,    true}.
 
 %@doc Marks connection as closed and appends data extracted from agent's JID
-doc_close_connection({}, _) -> {failure, nosession};
-doc_close_connection({Doc}, {User, _Host, _Resource}) ->
-  % Converts a list of tuples ([{x, Val}]) into a list of lists ([[x, Val]]) and flattens it ([x, Val]) for BSON
-  AgentData = erlang:list_to_tuple(lists:flatmap(fun erlang:tuple_to_list/1, parse_component_jid(User))),
+doc_close_connection({}) -> {failure, nosession};
+doc_close_connection({Doc}) ->
   NewData = {connected, false,
-             disconnected_at, bson:timenow(),
-             agent_data, AgentData},
+             disconnected_at, bson:timenow()},
   NewDoc = bson:merge(NewData, Doc),
   {ok, NewDoc}.
 


### PR DESCRIPTION
**Files included in the pull request**
`src/copilot-dashboard/js/dashboard2.config.js`: Dashboard now includes the number of connected machines in the last 7 days (per day)
`src/copilot-dashboard/js/dashboard2.js`: configuration file can now specify no to refresh for certain graphs
`src/copilot-ejabberd-module/src/mod_copilot.erl`: Updated names of the attributes extracted from Agent's JID and event when they get extracted (right after it connects to the server).
